### PR TITLE
Made more memory- and network-efficient.

### DIFF
--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -3,6 +3,7 @@
 var https = require('https'),
     fs = require('fs'),
     path = require('path'),
+    FormData = require('form-data'),
     args = process.argv.slice(2),
     argslen = args.length;
     
@@ -10,18 +11,12 @@ var https = require('https'),
 var imgur = (function () {
 
     var _req = null,
-        _endpoint = '/2/upload.json?key=',
+        _host = 'https://api.imgur.com',
+        _endpoint = '/2/upload.json',
         _key = '',
         _keyloc = process.env.HOME + '/.imgurkey',
         _filetypes_allowed = 'jpg jpeg gif png apng tiff bmp pdf xcf'.split(' '),
         _regex_filetypes_allowed = new RegExp('(' + _filetypes_allowed.join('|') + ')', 'i');
-        _request_options = {
-                host: 'api.imgur.com',
-                port: 443,
-                path: '',
-                method: 'POST',
-                headers: {}
-        };
 
 
     // Get saved API key (~/.imgurkey)
@@ -124,72 +119,65 @@ var imgur = (function () {
         if (!callback || typeof callback !== 'function') { 
             throw Error('_upload: No callback function specified');
         }
-        
-        // Open file and upload
-        _open(file, function (err, data, size) {
-            _request_options.path = _endpoint + _key;
-            _request_options.headers['Content-Length'] = size;
 
-            _req = https.request(_request_options, function(res) {
-                var body = '',
-                    ratelimit = {
-                        limit: null,
-                        remaining: null,
-                        reset: null
-                    },
-                    success = false;
+        var form = new FormData();
 
-                res.setEncoding('utf8');
-
-                if (res.statusCode === 200) { success = true; }
-                
-                if (typeof res.headers['x-ratelimit-limit'] !== 'undefined') {
-                    ratelimit.limit = res.headers['x-ratelimit-limit'];
-                    ratelimit.remaining = res.headers['x-ratelimit-remaining'];
-                    ratelimit.reset = res.headers['x-ratelimit-reset'];   
-                }
-                
-                res.on('data', function (chunk) {
-                    body += chunk;
-                });
-
-                res.on('end', function () {
-                    if (!success) {
-                        callback({
-                            'success': false,
-                            'error': JSON.parse(body).error.message,
-                            'status_code': res.StatusCode || 'Unknown',
-                            'rate': ratelimit,
-                            'file': file,
-                            'size': size,
-                            'body': body
-                        });
-                        return;  
-                    }
-                    
-                    callback({
-                        'success': success,
-                        'file': file,
-                        'size': size,
-                        'status_code': res.statusCode || 'Unknown',
-                        'rate': ratelimit,
-                        'links': JSON.parse(body).upload.links
-                    });
-                });
-            });
-
-            _req.on('error', function(e) {
+        form.append('key', _key);
+        form.append('type', 'file');
+        form.append('image', fs.createReadStream(file));
+        form.submit(_host + _endpoint, function(err, res) {
+            if (err) {
                 callback({
                     'success': false,
                     'file': file,
-                    'size': size,
                     'error': e
                 });
-            }); 
+                return;
+            }
 
-            _req.write(data);
-
-            _req.end(); 
+            var body = '',
+            ratelimit = {
+                limit: null,
+                remaining: null,
+                reset: null
+            },
+            success = false;
+            
+            res.setEncoding('utf8');
+            
+            if (res.statusCode === 200) { success = true; }
+            
+            if (typeof res.headers['x-ratelimit-limit'] !== 'undefined') {
+                ratelimit.limit = res.headers['x-ratelimit-limit'];
+                ratelimit.remaining = res.headers['x-ratelimit-remaining'];
+                ratelimit.reset = res.headers['x-ratelimit-reset'];   
+            }
+            
+            res.on('data', function (chunk) {
+                body += chunk;
+            });
+            
+            res.on('end', function () {
+                if (!success) {
+                    callback({
+                        'success': false,
+                        'error': body,
+                        'status_code': res.StatusCode || 'Unknown',
+                        'rate': ratelimit,
+                        'file': file,
+                        'body': body
+                    });
+                    return;  
+                }
+                
+                callback({
+                    'success': success,
+                    'file': file,
+                    'status_code': res.statusCode || 'Unknown',
+                    'rate': ratelimit,
+                    'links': JSON.parse(body).upload.links
+                });
+            });
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "engines": {
     "node": ">= v0.4.9"
   },
-  "dependencies": {},
+  "dependencies": {
+    "form-data": "~0.0.4"
+  },
   "devDependencies": {},
   "main": "lib/imgur.js",
   "bin": { "imgur": "./lib/imgur.js" }


### PR DESCRIPTION
Use Felix's FormData module ( https://npmjs.org/package/form-data ) to stream raw image file directly instead of buffering the entire file and base64-encoding it.

This uses less memory and causes less network traffic.
