### PR TITLE
Fix uploading url->album and add tests

### DIFF
--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -410,7 +410,7 @@ imgur.uploadUrl = function (url, albumId) {
         return deferred.promise;
     }
 
-    imgur._imgurRequest('upload', url)
+    imgur._imgurRequest('upload', url, extraFormParams)
         .then(function (json) {
             deferred.resolve(json);
         })

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "chai": "^1.9.1",
     "chai-as-promised": "^4.1.1",
-    "mocha": "^1.21.4"
+    "mocha": "^1.21.4",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/test/uploadUrl.js
+++ b/test/uploadUrl.js
@@ -1,0 +1,67 @@
+var imgur = require('../lib/imgur.js'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    sinon = require('sinon'),
+    sinonChai = require("sinon-chai"),
+    Q = require('q'),
+    expect = chai.expect;
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+describe('#uploadUrl()', function() {
+    describe('validation', function() {
+
+      it('should fail with no url', function(done) {
+          var errMsg = 'Invalid URL';
+
+          expect(imgur.uploadUrl())
+              .to.be.rejectedWith(errMsg)
+              .and.notify(done);
+      });
+
+      it('should fail with on a malformed url', function(done) {
+          var errMsg = 'Invalid URL';
+
+          expect(imgur.uploadUrl("blarg"))
+              .to.be.rejectedWith(errMsg)
+              .and.notify(done);
+      });
+    });
+
+    describe('delegates to #_imgurRequest(\'upload\', ...)', function() {
+      var mockResult = { foo: 'bar'};
+      var testUrl = "https://somewhere/test.png";
+
+      beforeEach(function() {
+        var deferred = Q.defer();
+        sinon.stub(imgur, "_imgurRequest").returns(deferred.promise);
+        deferred.resolve(mockResult);
+      });
+
+      afterEach(function () {
+        imgur._imgurRequest.restore();
+      });
+
+      it('should delegate', function(done) {
+        var promise = imgur.uploadUrl(testUrl);
+
+        expect(imgur._imgurRequest)
+            .to.have.been.calledWith('upload', testUrl);
+        expect(promise)
+            .to.eventually.equal(mockResult)
+            .and.notify(done);
+      });
+
+      it('should propagate albumId', function(done) {
+        var albumId = '123';
+        var promise = imgur.uploadUrl(testUrl, albumId);
+
+        expect(imgur._imgurRequest)
+            .to.have.been.calledWith('upload', testUrl, {album: albumId});
+        expect(promise)
+            .to.eventually.equal(mockResult)
+            .and.notify(done);
+      });
+    });
+});


### PR DESCRIPTION
Found that this didn't actually work because the extra options object was never being passed along. Added some tests and sinon as a dev dependency to mock the underlying call since that has its own, though currently sparse, tests.