### PR TITLE
fix error cause by sometimes body return without data attributes

### DIFF
--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -84,7 +84,7 @@ imgur._imgurRequest = function (operation, payload, extraFormParams) {
                 if (err) {
                     deferred.reject(err);
                 } else if (!body.success) {
-                    deferred.reject({status: body.status, message: body.data.error});
+                    deferred.reject({status: body.status, message: body.data ? body.data.error : 'No body data response'});
                 } else {
                     deferred.resolve(body);
                 }


### PR DESCRIPTION
Should check whether **body.data** exits or not before using **body.data.error**. 
Example error lists below:

```
TypeError: Cannot read property 'error' of undefined
    at Request._callback (/home/Dcard/Dcard/node_modules/imgur/lib/imgur.js:87:77)
    at Request.self.callback (/home/Dcard/Dcard/node_modules/request/request.js:198:22)
    at Request.emit (events.js:110:17)
    at Request. (/home/Dcard/Dcard/node_modules/request/request.js:1073:14)
    at Request.emit (events.js:129:20)
    at IncomingMessage. (/home/Dcard/Dcard/node_modules/request/request.js:1019:12)
    at IncomingMessage.emit (events.js:129:20)
    at _stream_readable.js:908:16
    at process._tickDomainCallback [as _tickCallback] (node.js:381:11)
```
