### PR TITLE
Added methods to set API Url, MashapeKey and delete images based on deletehash

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,20 @@ imgur.uploadAlbum(images, uploadType /*, failSafe */)
 
 ```
 
+#### Deleting anonymous uploads
+
+Delete an image based on the deletehash(generated during the image upload)
+
+```javascript
+imgur.deleteImage(deletehash)
+    .then(function(status) {
+        console.log(status);  
+    })
+    .catch(function(err) {
+        console.error(err.message);
+    });
+```
+
 ## License
 
 #### MIT

--- a/README.md
+++ b/README.md
@@ -125,14 +125,15 @@ In order to change the API Url say Mashape URL, use setAPIUrl(MashapeURL)
 //Setting
 imgur.setAPIUrl('https://api.imgur.com/3/');
 
-If setAPIUrl() is not called, API URL is read from process.env.IMGUR_API_URL
+//If setAPIUrl() is not called, API URL is read from process.env.IMGUR_API_URL
 
 //Getting
 imgur.getAPIUrl();
-
+```
 #### Dealing with Mashape Key
 
-Requests to the Mashape URL expects a X-Mashape-Key: MashapeKey header. Set Mashape Key by using setMashapeKey(MashapeKey) method.
+Requests to the Mashape URL expects a X-Mashape-Key: MashapeKey header. 
+Set Mashape Key by using setMashapeKey(MashapeKey) method.
 Note: Defaults to process.env.IMGUR_MASHAPE_KEY
 
 ```javascript
@@ -141,7 +142,7 @@ imgur.setMashapeKey(https://imgur-apiv3.p.mashape.com/);
 
 //Getting
 imgur.getMashapeKey()
-
+```
 #### Dealing with credentials:
 
 For when you want to upload images to an account.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,30 @@ imgur.saveClientId(path)
 imgur.loadClientId(path)
     .then(imgur.setClientId);
 ```
+#### Dealing with API URL:
+
+In order to change the API Url say Mashape URL, use setAPIUrl(MashapeURL)
+
+```javascript
+//Setting
+imgur.setAPIUrl('https://api.imgur.com/3/');
+
+If setAPIUrl() is not called, API URL is read from process.env.IMGUR_API_URL
+
+//Getting
+imgur.getAPIUrl();
+
+#### Dealing with Mashape Key
+
+Requests to the Mashape URL expects a X-Mashape-Key: MashapeKey header. Set Mashape Key by using setMashapeKey(MashapeKey) method.
+Note: Defaults to process.env.IMGUR_MASHAPE_KEY
+
+```javascript
+//Setting
+imgur.setMashapeKey(https://imgur-apiv3.p.mashape.com/);
+
+//Getting
+imgur.getMashapeKey()
 
 #### Dealing with credentials:
 

--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -70,6 +70,9 @@ imgur._imgurRequest = function (operation, payload, extraFormParams) {
             options.method = 'POST';
             options.uri += 'album';
             break;
+        case 'delete':
+            options.method = 'DELETE';
+            options.uri += 'image/' + payload;
         default:
             deferred.reject(new Error('Invalid operation'));
             return deferred.promise;
@@ -323,6 +326,28 @@ imgur.setMashapeKey = function(mashapeKey) {
  */
 imgur.getMashapeKey = function() {
     return IMGUR_MASHAPE_KEY;
+}
+
+/**
+ * Delete image
+ * @param {string} deletehash - deletehash of the image generated during upload
+ * @returns {promise}
+ */
+imgur.deleteImage = function (deletehash) {
+    var deferred = Q.defer();
+
+    if(!deletehash) {
+        deferred.reject('Missing deletehash');
+    }
+
+    imgur._imgurRequest('delete', deletehash)
+        .then(function (json) {
+            deferred.resolve(json);
+        })
+        .catch(function (err) {
+            deferred.reject(err);
+        });
+    return deferred.promise;
 }
 
 /**

--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -73,6 +73,7 @@ imgur._imgurRequest = function (operation, payload, extraFormParams) {
         case 'delete':
             options.method = 'DELETE';
             options.uri += 'image/' + payload;
+            break;
         default:
             deferred.reject(new Error('Invalid operation'));
             return deferred.promise;

--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -10,11 +10,12 @@ var glob      = require('glob');
 // registered 'node-imgur' app and is available
 // here for public, anonymous usage via this node
 // module only.
-var IMGUR_CLIENT_ID    = 'f0ea04148a54268';
-var IMGUR_API_URL      = 'https://api.imgur.com/3/';
+var IMGUR_CLIENT_ID    = process.env.IMGUR_CLIENT_ID || 'f0ea04148a54268';
+var IMGUR_API_URL      = process.env.IMGUR_API_URL || 'https://api.imgur.com/3/';
 var IMGUR_USERNAME     = null;
 var IMGUR_PASSWORD     = null;
 var IMGUR_ACCESS_TOKEN = null;
+var IMGUR_MASHAPE_KEY  = process.env.IMGUR_MASHAPE_KEY;
 
 // An IIFE that returns the OS-specific home directory
 // as a location to optionally store the imgur client id
@@ -76,9 +77,16 @@ imgur._imgurRequest = function (operation, payload, extraFormParams) {
 
     imgur._getAuthorizationHeader()
         .then(function (authorizationHeader) {
-            options.headers = {
-                Authorization: authorizationHeader
-            };
+            if(IMGUR_MASHAPE_KEY) {
+                options.headers = {
+                    Authorization: authorizationHeader,
+                    'X-Mashape-Key': IMGUR_MASHAPE_KEY
+                };
+            } else {
+                options.headers = {
+                    Authorization: authorizationHeader
+                };
+            }
 
             var r = request(options, function (err, res, body) {
                 if (err) {
@@ -280,6 +288,42 @@ imgur.getClientId = function () {
     return IMGUR_CLIENT_ID;
 }
 
+/**
+ * Set Imgur API URL
+ * @link https://api.imgur.com/#register or https://imgur-apiv3.p.mashape.com
+ * @param {string} URL - URL to make the API calls to imgur
+ */
+imgur.setAPIUrl = function(URL) {
+    if(URL && typeof URL === 'string') {
+        IMGUR_API_URL = URL;
+    }
+}
+
+/**
+ * Get Imgur API Url
+ * @returns {string} API Url
+ */
+imgur.getAPIUrl = function() {
+    return IMGUR_API_URL;
+}
+
+/**
+ * Set Mashape Key
+ * @link https://market.mashape.com/imgur/imgur-9
+ * @param {string} mashapeKey
+ */
+imgur.setMashapeKey = function(mashapeKey) {
+    if(mashapeKey && typeof mashapeKey === 'string') {
+        IMGUR_MASHAPE_KEY = mashapeKey;
+    }
+}
+/**
+ * Get Mashape Key
+ * @returns {string} Mashape Key
+ */
+imgur.getMashapeKey = function() {
+    return IMGUR_MASHAPE_KEY;
+}
 
 /**
  * Get image metadata

--- a/test/getAPIUrl.js
+++ b/test/getAPIUrl.js
@@ -1,0 +1,20 @@
+var imgur = require('../lib/imgur.js'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    expect = chai.expect;
+
+chai.use(chaiAsPromised);
+
+describe('#getAPIUrl()', function() {
+    it('should return the default API URL, if nothing is set', function() {
+        var defaultAPIUrl = 'https://api.imgur.com/3/';
+        return expect(imgur.getAPIUrl()).to.equal(defaultAPIUrl);
+    });
+
+    it('should return the same API URL that was set', function() {
+        var apiUrl = 'https://imgur-apiv3.p.mashape.com/';
+        imgur.setAPIUrl(apiUrl);
+
+        return expect(imgur.getAPIUrl()).to.equal(apiUrl);
+    });
+});

--- a/test/getMashapeKey.js
+++ b/test/getMashapeKey.js
@@ -1,0 +1,15 @@
+var imgur = require('../lib/imgur.js'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    expect = chai.expect;
+
+chai.use(chaiAsPromised);
+
+describe('#getMashapeKey()', function() {
+    it('should return the same client that was set', function() {
+        var mashapeKey = '123456789abcdef';
+        imgur.setMashapeKey(mashapeKey);
+
+        return expect(imgur.getMashapeKey()).to.equal(mashapeKey);
+    });
+});

--- a/test/setAPIUrl.js
+++ b/test/setAPIUrl.js
@@ -1,0 +1,37 @@
+var imgur = require('../lib/imgur.js'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    expect = chai.expect;
+
+chai.use(chaiAsPromised);
+
+describe('#setAPIUrl()', function() {
+    beforeEach(function() {
+        var defaultImgurAPIUrl = 'https://api.imgur.com/3/';
+        imgur.setAPIUrl(defaultImgurAPIUrl);
+    });
+
+    it('should return the API Url that was set', function() {
+        var imgurAPIUrl = 'https://imgur-apiv3.p.mashape.com/';
+        imgur.setAPIUrl(imgurAPIUrl);
+        return expect(imgur.getAPIUrl()).to.equal(imgurAPIUrl);
+    });
+
+    it('should not set an empty API Url', function() {
+        var imgurAPIUrl = '';
+        imgur.setAPIUrl(imgurAPIUrl);
+        return expect(imgur.getAPIUrl()).to.not.equal(imgurAPIUrl);
+    });
+
+    it('should not set a number', function() {
+        var imgurAPIUrl = 1024;
+        imgur.setAPIUrl(imgurAPIUrl);
+        return expect(imgur.getAPIUrl()).to.not.equal(imgurAPIUrl);
+    });
+
+    it('should not set a boolean', function() {
+        var imgurAPIUrl = false;
+        imgur.setAPIUrl(imgurAPIUrl);
+        return expect(imgur.getAPIUrl()).to.not.equal(imgurAPIUrl);
+    });
+});

--- a/test/setMashapeKey.js
+++ b/test/setMashapeKey.js
@@ -1,0 +1,37 @@
+var imgur = require('../lib/imgur.js'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    expect = chai.expect;
+
+chai.use(chaiAsPromised);
+
+describe('#setMashapeKey()', function() {
+    beforeEach(function() {
+        var defaultMashapeKey = '0123456789abcdef';
+        imgur.setMashapeKey(defaultMashapeKey);
+    });
+
+    it('should return the Mashape Key that was set', function() {
+        var mashapeKey = '0123456789abcdef';
+        imgur.setMashapeKey(mashapeKey);
+        return expect(imgur.getMashapeKey()).to.equal(mashapeKey);
+    });
+
+    it('should not set an empty Mashape Key', function() {
+        var mashapeKey = '';
+        imgur.setMashapeKey(mashapeKey);
+        return expect(imgur.getMashapeKey()).to.not.equal(mashapeKey);
+    });
+
+    it('should not set a number', function() {
+        var mashapeKey = 1024;
+        imgur.setMashapeKey(mashapeKey);
+        return expect(imgur.getMashapeKey()).to.not.equal(mashapeKey);
+    });
+
+    it('should not set a boolean', function() {
+        var mashapeKey = false;
+        imgur.setMashapeKey(mashapeKey);
+        return expect(imgur.getMashapeKey()).to.not.equal(mashapeKey);
+    });
+});


### PR DESCRIPTION
- setAPIUrl to change the default API URL(Mashape URL)
- getAPIUrl returns the current API URL
- setMashapeKey to set the MashapeKey. Defaults to process.env.IMGUR_MASHAPE_KEY
- getMashapeKey returns the current MashapeKey
- deleteImage to delete an image based on the image's deletehash
- Added Headers to use X-Mashape-Key: MashapeKey header if MashapeKey is set
- Added tests for the same
- Updated README
