### PR TITLE
UploadImages accepts array of image objects or strings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn\.lock

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ imgur.uploadBase64(imgurFavicon)
 
 #### Uploading multiple images:
 
-Upload an array of images of the desired upload type ('File', 'Url', 'Base64').
+Upload an array of image files or image objects containing title and description `{(string | Object[{file: string, title: string, description: string}])}` of the desired upload type ('File', 'Url', 'Base64').
 
 Returns an array of images (imgur image data).
 

--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -652,7 +652,7 @@ imgur.uploadAlbum = function (images, uploadType, failSafe) {
 
 /**
  * Upload an entire album of images
- * @param {Array} images  - array of image strings of desired type
+ * @param {object} images  - array of image objects containing file, optional title and description [{file: ..., title: ..., description: ...}, ...]
  * @param {string} uploadType - the type of the upload ('File', 'Url', 'Base64')
  * @param {string=} albumId - the album id to upload to
  * @returns {promise} - on resolve, returns an array of image data objects {album: {...}, images: [{...}, ...]}
@@ -661,8 +661,13 @@ imgur.uploadImages = function (images, uploadType, albumId) {
     var deferred = Q.defer();
     var upload = imgur['upload' + uploadType];
 
-    if (!images || !images.length || !(typeof images === 'string' || images instanceof Array)) {
+    if (!images || !images.length || !(images instanceof Array)) {
         deferred.reject(new Error('Invalid image input, only arrays supported'));
+        return deferred.promise;
+    }
+
+    if (typeof images[0] !== 'object') {
+        deferred.reject(new Error('Invalid array input, only image objects supported'));
         return deferred.promise;
     }
 
@@ -670,7 +675,7 @@ imgur.uploadImages = function (images, uploadType, albumId) {
     var progress = 0;
     var done = images.length;
     for (var i = 0; i < done; i++) {
-        upload(images[i], albumId)
+        upload(images[i].file, albumId, images[i].title, images[i].description)
             .then(function (image) {
                 results.push(image.data);
                 ++progress;

--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -652,7 +652,7 @@ imgur.uploadAlbum = function (images, uploadType, failSafe) {
 
 /**
  * Upload an entire album of images
- * @param {array [string|object]} images  - array of image objects containing file, optional title and description [{file: ..., title: ..., description: ...}, ...] | array of image strings of desired type
+ * @param {(string | Object[{file: string, title: string, description: string}])} images  - array of image objects containing file, optional title and description [{file: ..., title: ..., description: ...}, ...] | array of image strings of desired type
  * @param {string} uploadType - the type of the upload ('File', 'Url', 'Base64')
  * @param {string=} albumId - the album id to upload to
  * @returns {promise} - on resolve, returns an array of image data objects {album: {...}, images: [{...}, ...]}

--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -652,7 +652,7 @@ imgur.uploadAlbum = function (images, uploadType, failSafe) {
 
 /**
  * Upload an entire album of images
- * @param {object} images  - array of image objects containing file, optional title and description [{file: ..., title: ..., description: ...}, ...]
+ * @param {array [string|object]} images  - array of image objects containing file, optional title and description [{file: ..., title: ..., description: ...}, ...] | array of image strings of desired type
  * @param {string} uploadType - the type of the upload ('File', 'Url', 'Base64')
  * @param {string=} albumId - the album id to upload to
  * @returns {promise} - on resolve, returns an array of image data objects {album: {...}, images: [{...}, ...]}
@@ -661,13 +661,12 @@ imgur.uploadImages = function (images, uploadType, albumId) {
     var deferred = Q.defer();
     var upload = imgur['upload' + uploadType];
 
-    if (!images || !images.length || !(images instanceof Array)) {
-        deferred.reject(new Error('Invalid image input, only arrays supported'));
-        return deferred.promise;
-    }
-
-    if (typeof images[0] !== 'object') {
-        deferred.reject(new Error('Invalid array input, only image objects supported'));
+    if (!images || !images.length || !(typeof images === 'object' || typeof images === 'string' || images instanceof Array)) {
+        if (failSafe) {
+            deferred.resolve({data: {}, images: []});
+        } else {
+            deferred.reject(new Error('Invalid image input, only arrays supported'));
+        }
         return deferred.promise;
     }
 
@@ -675,7 +674,21 @@ imgur.uploadImages = function (images, uploadType, albumId) {
     var progress = 0;
     var done = images.length;
     for (var i = 0; i < done; i++) {
-        upload(images[i].file, albumId, images[i].title, images[i].description)
+        if (typeof images[0] === 'object') {
+            upload(images[i].file, albumId, images[i].title, images[i].description)
+            .then(function (image) {
+                results.push(image.data);
+                ++progress;
+                if (progress == done) {
+                    deferred.resolve(results);
+                }
+            })
+            .catch(function (err) {
+                deferred.reject(err);
+                return deferred.promise;
+            });    
+        } else {
+            upload(images[i], albumId)
             .then(function (image) {
                 results.push(image.data);
                 ++progress;
@@ -687,6 +700,9 @@ imgur.uploadImages = function (images, uploadType, albumId) {
                 deferred.reject(err);
                 return deferred.promise;
             });
+        }
+
+        
     }
 
     return deferred.promise;


### PR DESCRIPTION
Edited the `imgur.uploadImages(images, uploadType /*, albumId */)` to be able to accept optional title and descriptions for each image in array.

Array of objects would look like:
```
[{
 title: "cool image",
 description: "cool description",
 file: "./coolimage.jpg"
}]
```
or original Array of image string still works.

Apologies if my function comments/README updates are confusing.