### PR TITLE
Upgrade glob and mocha to resolve critical security vulnerabilities

### DIFF
--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -45,6 +45,7 @@ imgur._imgurRequest = function (operation, payload, extraFormParams) {
     };
 
     if (!operation || typeof operation !== 'string' || ( !payload && operation !== ('credits' && 'search') ) ) {
+        deferred.reject(new Error('Invalid argument'));
         return deferred.promise;
     }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "commander": "^2.3.0",
-    "glob": "^4.0.5",
+    "glob": "^7.1.2",
     "q": "^1.0.1",
     "request": "^2.40.0"
   },
@@ -33,7 +33,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
-    "mocha": "^2.3.3",
+    "mocha": "^5.2.0",
     "sinon": "^1.17.1",
     "sinon-chai": "^2.8.0"
   }


### PR DESCRIPTION
This branch upgrades two of this projects dependencies, `glob` and `mocha` to address security vulnerabilities exposed by `npm audit`.

The `glob` (actually its `minimatch` dependency) problem: https://nodesecurity.io/advisories/118
The `mocha` (actually its `growl` dependency) problem: https://nodesecurity.io/advisories/146

While I was at it, I fixed an unrelated, but broken test since I wanted to make sure that the dependency upgrades didn't affect the package's stability.