### PR TITLE
refactor(authorization): remove built-in authorization flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,29 +92,18 @@ npm install imgur
 const imgur = require('imgur');
 ```
 
-#### Dealing with client IDs:
+#### Authentication
+
+First, you must register your application with Imgur if you haven't already done so.
+
+You can set either your client ID or access token (you must perform this flow separately):
 
 ```javascript
-// Setting
 imgur.setClientId('aCs53GSs4tga0ikp');
 
-// Getting
-imgur.getClientId();
+// ...or..
 
-// Saving to disk. Returns a promise.
-// NOTE: path is optional. Defaults to ~/.imgur
-imgur
-  .saveClientId(path)
-  .then(() => {
-    console.log('Saved.');
-  })
-  .catch((err) => {
-    console.log(err.message);
-  });
-
-// Loading from disk
-// NOTE: path is optional. Defaults to ~/.imgur
-imgur.loadClientId(path).then(imgur.setClientId);
+imgur.setAccessToken('youraccesstoken');
 ```
 
 #### Dealing with API URL:
@@ -143,15 +132,6 @@ imgur.setMashapeKey(https://imgur-apiv3.p.mashape.com/);
 
 //Getting
 imgur.getMashapeKey()
-```
-
-#### Dealing with credentials:
-
-For when you want to upload images to an account.
-
-```javascript
-// Setting
-imgur.setCredentials('email@domain.com', 'password', 'aCs53GSs4tga0ikp');
 ```
 
 #### Uploading files; globbing supported:

--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -13,8 +13,6 @@ const VERSION = require('../package.json').version;
 let imgurClientId = process.env.IMGUR_CLIENT_ID || 'f0ea04148a54268';
 let imgurApiUrl = process.env.IMGUR_API_URL || 'https://api.imgur.com/3/';
 let imgurMashapeKey = process.env.IMGUR_MASHAPE_KEY;
-let imgurUsername = null;
-let imgurPassword = null;
 let imgurAccessToken = null;
 
 // An IIFE that returns the OS-specific home directory
@@ -83,7 +81,7 @@ imgur._imgurRequest = async (operation, payload, extraFormParams) => {
       throw new Error('Invalid operation');
   }
 
-  const authorizationHeader = await imgur._getAuthorizationHeader();
+  const authorizationHeader = imgur._getAuthorizationHeader();
 
   if (imgurMashapeKey) {
     options.headers = {
@@ -134,54 +132,12 @@ imgur._request = async (options) => await got(options).json();
  *
  * @returns {promise}
  */
-imgur._getAuthorizationHeader = async () => {
+imgur._getAuthorizationHeader = () => {
   if (imgurAccessToken) {
     return `Bearer ${imgurAccessToken}`;
   }
 
-  if (!(imgurUsername && imgurPassword)) {
-    return `Client-ID ${imgurClientId}`;
-  }
-
-  const options = {
-    uri: 'https://api.imgur.com/oauth2/authorize',
-    method: 'GET',
-    encoding: 'utf8',
-    searchParams: {
-      client_id: imgurClientId,
-      response_type: 'token',
-    },
-  };
-
-  let response;
-
-  response = await imgur._request(options);
-  const authorize_token = response.headers['set-cookie'][0].match(
-    '(^|;)[s]*authorize_token=([^;]*)'
-  )[2];
-
-  options.method = 'POST';
-  options.form = {
-    username: imgurUsername,
-    password: imgurPassword,
-    allow: authorize_token,
-  };
-  options.headers = {
-    Cookie: 'authorize_token=' + authorize_token,
-  };
-
-  response = await imgur._request(options);
-  const location = response.headers.location;
-  const token = JSON.parse(
-    '{"' +
-      decodeURI(location.slice(location.indexOf('#') + 1))
-        .replace(/"/g, '\\"')
-        .replace(/&/g, '","')
-        .replace(/=/g, '":"') +
-      '"}'
-  );
-  imgurAccessToken = token.access_token;
-  return `Bearer ${imgurAccessToken}`;
+  return `Client-ID ${imgurClientId}`;
 };
 
 /**
@@ -192,25 +148,6 @@ imgur._getAuthorizationHeader = async () => {
 imgur.setAccessToken = function (accessToken) {
   if (accessToken && typeof accessToken === 'string') {
     imgurAccessToken = accessToken;
-  }
-};
-
-/**
- * Set your credentials
- * @link https://api.imgur.com/#register
- * @param {string} username
- * @param {string} password
- * @param {string} clientId
- */
-imgur.setCredentials = (username, password, clientId) => {
-  if (clientId && typeof clientId === 'string') {
-    imgurClientId = clientId;
-  }
-  if (username && typeof username === 'string') {
-    imgurUsername = username;
-  }
-  if (password && typeof password === 'string') {
-    imgurPassword = password;
   }
 };
 


### PR DESCRIPTION
(technically already broken..)

BREAKING CHANGE: Imgur no longer supports the `Resource Owner Password Credentials Grant` type,
so the outdated (i.e., broken) code that requires your username and password has been removed.
You must now manage the `Authorization Code Grant` type flow yourself to obtain an access token
via server redirect/callback and then provide it to this module via `setAccessToken`

closes #115