### PR TITLE
Update upload endpoint

### DIFF
--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -54,7 +54,7 @@ imgur._imgurRequest = async (operation, payload, extraFormParams) => {
   switch (operation) {
     case 'upload':
       options.method = 'POST';
-      options.url += 'image';
+      options.url += 'upload';
       break;
     case 'credits':
       options.method = 'GET';

--- a/lib/mocks/handlers.js
+++ b/lib/mocks/handlers.js
@@ -1,18 +1,8 @@
 const { rest } = require('msw');
+const upload = require('./handlers/upload');
 
 const handlers = [
-  rest.post('https://api.imgur.com/3/image', (_req, res, ctx) => {
-    const response = {
-      data: {
-        id: 'JK9ybyj',
-        deletehash: 'j83zimv4VtDA0Xp',
-        link: 'https://i.imgur.com/JK9ybyj.jpg',
-      },
-      success: true,
-      status: 200,
-    };
-    return res(ctx.json(response));
-  }),
+  rest.post('https://api.imgur.com/3/upload', upload.postHandler),
   rest.get('https://api.imgur.com/3/gallery/JK9ybyj', (_req, res, ctx) => {
     const response = {
       data: {

--- a/lib/mocks/handlers/upload.js
+++ b/lib/mocks/handlers/upload.js
@@ -1,0 +1,45 @@
+const BadRequestErrorResponse = {
+  status: 400,
+  success: false,
+  data: {
+    error: 'Bad Request',
+    request: '/3/upload',
+    method: 'POST',
+  },
+};
+
+const SuccessfulUploadResponse = {
+  data: {
+    id: 'JK9ybyj',
+    deletehash: 'j83zimv4VtDA0Xp',
+    link: 'https://i.imgur.com/JK9ybyj.jpg',
+  },
+  success: true,
+  status: 200,
+};
+
+function postHandler(req, res, ctx) {
+  // image field is always required
+  if (!('image' in req.body)) {
+    return res(ctx.code(400), ctx.json(BadRequestErrorResponse));
+  }
+
+  // type is optional when uploading a file, but required
+  // for any other type
+  if ('type' in req.body) {
+    // only these types are allowed
+    if (!['file', 'url', 'base64'].includes(req.body.type)) {
+      return res(ctx.code(400), ctx.json(BadRequestErrorResponse));
+    }
+    // if type is not specified we assume we're uploading a file.
+    // but we need to make sure a file was sent in the image field
+  } else if (typeof req.body.image !== 'object') {
+    return res(ctx.code(400), ctx.json(BadRequestErrorResponse));
+  }
+
+  return res(ctx.json(SuccessfulUploadResponse));
+}
+
+module.exports = {
+  postHandler,
+};


### PR DESCRIPTION
this aligns with the official API. uploading to /image is no longer documented so we'll stop pointing there before it breaks.

I also pulled out the upload handler mock to its own file and added a bunch more checks to ensure all cases are covered in the tests.